### PR TITLE
Add workflows to perform tests on modules

### DIFF
--- a/.github/workflows/tf.test.azure.bastion.yml
+++ b/.github/workflows/tf.test.azure.bastion.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/bastion
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.bastion.yml
+      - azure/bastion/*.tf
+      - azure/bastion/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.bastion.yml
+      - azure/bastion/*.tf
+      - azure/bastion/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/bastion
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.container-registry.yml
+++ b/.github/workflows/tf.test.azure.container-registry.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/container-registry
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.container-registry.yml
+      - azure/container-registry/*.tf
+      - azure/container-registry/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.container-registry.yml
+      - azure/container-registry/*.tf
+      - azure/container-registry/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/container-registry
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.kubernetes-service.yml
+++ b/.github/workflows/tf.test.azure.kubernetes-service.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/kubernetes-service
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.kubernetes-service.yml
+      - azure/kubernetes-service/*.tf
+      - azure/kubernetes-service/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.kubernetes-service.yml
+      - azure/kubernetes-service/*.tf
+      - azure/kubernetes-service/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/kubernetes-service
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.linux-functionapp.yml
+++ b/.github/workflows/tf.test.azure.linux-functionapp.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/linux-functionapp
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.linux-functionapp.yml
+      - azure/linux-functionapp/*.tf
+      - azure/linux-functionapp/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.linux-functionapp.yml
+      - azure/linux-functionapp/*.tf
+      - azure/linux-functionapp/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/linux-functionapp
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.linux-virtual-machine.yml
+++ b/.github/workflows/tf.test.azure.linux-virtual-machine.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/linux-virtual-machine
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.linux-virtual-machine.yml
+      - azure/linux-virtual-machine/*.tf
+      - azure/linux-virtual-machine/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.linux-virtual-machine.yml
+      - azure/linux-virtual-machine/*.tf
+      - azure/linux-virtual-machine/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/linux-virtual-machine
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.linux-webapp.yml
+++ b/.github/workflows/tf.test.azure.linux-webapp.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/linux-webapp
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.linux-webapp.yml
+      - azure/linux-webapp/*.tf
+      - azure/linux-webapp/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.linux-webapp.yml
+      - azure/linux-webapp/*.tf
+      - azure/linux-webapp/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/linux-webapp
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.network-security-group.yml
+++ b/.github/workflows/tf.test.azure.network-security-group.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/network-security-group
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.network-security-group.yml
+      - azure/network-security-group/*.tf
+      - azure/network-security-group/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.network-security-group.yml
+      - azure/network-security-group/*.tf
+      - azure/network-security-group/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/network-security-group
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.policy-baseline.yml
+++ b/.github/workflows/tf.test.azure.policy-baseline.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/policy-baseline
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.policy-baseline.yml
+      - azure/policy-baseline/*.tf
+      - azure/policy-baseline/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.policy-baseline.yml
+      - azure/policy-baseline/*.tf
+      - azure/policy-baseline/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/policy-baseline
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.power-management.yml
+++ b/.github/workflows/tf.test.azure.power-management.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/power-management
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.power-management.yml
+      - azure/power-management/*.tf
+      - azure/power-management/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.power-management.yml
+      - azure/power-management/*.tf
+      - azure/power-management/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/power-management
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.terraform-ops.yml
+++ b/.github/workflows/tf.test.azure.terraform-ops.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/terraform-ops
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.terraform-ops.yml
+      - azure/terraform-ops/*.tf
+      - azure/terraform-ops/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.terraform-ops.yml
+      - azure/terraform-ops/*.tf
+      - azure/terraform-ops/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/terraform-ops
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.virtual-network.yml
+++ b/.github/workflows/tf.test.azure.virtual-network.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/virtual-network
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.virtual-network.yml
+      - azure/virtual-network/*.tf
+      - azure/virtual-network/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.virtual-network.yml
+      - azure/virtual-network/*.tf
+      - azure/virtual-network/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/virtual-network
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azure.windows-virtual-machine.yml
+++ b/.github/workflows/tf.test.azure.windows-virtual-machine.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azure/windows-virtual-machine
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.windows-virtual-machine.yml
+      - azure/windows-virtual-machine/*.tf
+      - azure/windows-virtual-machine/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azure.windows-virtual-machine.yml
+      - azure/windows-virtual-machine/*.tf
+      - azure/windows-virtual-machine/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azure/windows-virtual-machine
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.azuredevops.project.yml
+++ b/.github/workflows/tf.test.azuredevops.project.yml
@@ -1,0 +1,29 @@
+name: terraform - test - azuredevops/project
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azuredevops.project.yml
+      - azuredevops/project/*.tf
+      - azuredevops/project/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.azuredevops.project.yml
+      - azuredevops/project/*.tf
+      - azuredevops/project/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: azuredevops/project
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.github.repository.yml
+++ b/.github/workflows/tf.test.github.repository.yml
@@ -1,0 +1,29 @@
+name: terraform - test - github/repository
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.github.repository.yml
+      - github/repository/*.tf
+      - github/repository/*.hcl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tf.test.yml
+      - .github/workflows/tf.test.github.repository.yml
+      - github/repository/*.tf
+      - github/repository/*.hcl
+
+jobs:
+  test:
+    uses: ./.github/workflows/tf.test.yml
+    with:
+      tf_path: github/repository
+      tf_version: latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write

--- a/.github/workflows/tf.test.yml
+++ b/.github/workflows/tf.test.yml
@@ -1,0 +1,122 @@
+######################################################
+# Terraform Test Workflow
+#
+# Performs a simple test to ensure that Terraform is:
+# - Formatted correctly
+# - Initializes without a backend
+# - Validates
+#
+# ###OMITTED###
+# # permissions block is required
+# # to ensure it can write to checks and PRs
+# jobs:
+#   module_test_job:
+#     uses: ./.github/workflows/tf.test.yml
+#     with:
+#       tf_path: path/to/module
+#     permissions:
+#       contents: read
+#       checks: write
+#       pull-requests: write
+# ###OMITTED###
+######################################################
+
+name: terraform - test
+
+# workflow triggers
+on:
+  # enables manual runs
+  workflow_call:
+    inputs:
+      tf_version:
+        required: false
+        type: string
+        description: Terraform version to use.
+        default: latest
+      tf_path:
+        required: false
+        type: string
+        description: Path to the location of your Terraform configuration or module.
+        default: ${{ vars.GITHUB_WORKSPACE }}
+      reviewdog_pr_reporter:
+        required: false
+        type: string
+        description: The reporter to use with Reviewdog and PR.
+        default: github-pr-review
+
+# set global pipeline env vars
+env:
+  tf_version: ${{ inputs.tf_version }}
+  tf_path: ${{ inputs.tf_path }}
+
+# workflow
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.tf_path }}
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    env:
+      TF_IN_AUTOMATION: true
+      TF_INPUT: false
+      TF_CLI_ARGS_init: -backend=false
+    steps:
+      # checkout
+      - uses: actions/checkout@v3
+
+      # setup
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.tf_version }}
+
+      # base checks
+      - name: terraform fmt
+        run: terraform fmt -check
+        continue-on-error: true
+      - name: terraform init
+        run: terraform init
+      - name: terraform validate
+        run: terraform validate
+
+      # custom checks (push)
+      - name: tflint
+        uses: reviewdog/action-tflint@v1
+        with:
+          working_directory: ${{ env.tf_path }}
+          filter_mode: nofilter
+          reporter: github-check
+          fail_on_error: false
+          tflint_init: true
+        if: github.event_name != 'pull_request'
+      - name: tfsec
+        uses: reviewdog/action-tfsec@v1
+        with:
+          working_directory: ${{ env.tf_path }}
+          filter_mode: nofilter
+          reporter: github-check
+          fail_on_error: true
+        if: github.event_name != 'pull_request'
+
+      # custom checks (pr)
+      - name: tflint-pr
+        uses: reviewdog/action-tflint@v1
+        with:
+          working_directory: ${{ env.tf_path }}
+          filter_mode: nofilter
+          reporter: ${{ inputs.reviewdog_pr_reporter }}
+          fail_on_error: false
+          tflint_init: true
+        if: github.event_name == 'pull_request'
+      - name: tfsec-pr
+        uses: reviewdog/action-tfsec@v1
+        with:
+          working_directory: ${{ env.tf_path }}
+          filter_mode: nofilter
+          reporter: ${{ inputs.reviewdog_pr_reporter }}
+          fail_on_error: true
+        if: github.event_name == 'pull_request'


### PR DESCRIPTION
This PR includes a reusable workflow to reduce code duplication and a workflow for every available module.

The workflow does the following:

- terraform fmt -check, followed by an init and validate
- tflint which uses a check or pr comment
- tfsec which uses a check or pr comment

This aids with bringing confidence to the modules that will work and use the latest version of Terraform by default