### PR TITLE
Azure Virtual Network - Split dns_servers Into Separate Resource

### DIFF
--- a/azure/virtual-network/README.md
+++ b/azure/virtual-network/README.md
@@ -62,6 +62,7 @@ This module will create an Azure Virtual Network with subnets using a complex ob
 | [azurerm_subnet_network_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_subnet_route_table_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_dns_servers.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_dns_servers) | resource |
 | [azurerm_virtual_network_peering.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 
 ## Modules

--- a/azure/virtual-network/main.tf
+++ b/azure/virtual-network/main.tf
@@ -25,7 +25,6 @@ resource "azurerm_virtual_network" "main" {
   tags                = var.tags
 
   address_space = var.address_space
-  dns_servers   = var.dns_servers
 
   bgp_community = var.bgp_community
   dynamic "ddos_protection_plan" {
@@ -36,6 +35,11 @@ resource "azurerm_virtual_network" "main" {
       enable = true
     }
   }
+}
+
+resource "azurerm_virtual_network_dns_servers" "main" {
+  virtual_network_id = azurerm_virtual_network.main.id
+  dns_servers        = var.dns_servers
 }
 
 resource "azurerm_virtual_network_peering" "main" {


### PR DESCRIPTION
# Azure Virtual Network

Split dns_servers into a dedicated virtual network by moving the dns_servers property out of azurerm_virtual_network.main and setting it up in azurerm_virtual_network_dns_servers.main

This change is so that you can specify DNS servers for the virtual network and avoid cyclical dependency errors for example: if creating an Azure Firewall and you are passing that in as a DNS Server, it has caused a conflict like below due to how things are mapped.

```
╷
│ Error: Cycle: module.uks_hub_network.var.dns_servers (expand), module.uks_hub_network.azurerm_virtual_network.main, module.uks_hub_network.azurerm_subnet.main, module.uks_hub_network.output.subnets (expand), azurerm_firewall.uks_hub
│ 
│ 
```

Raising as a feature / improvement as this will not always be the case.